### PR TITLE
fix for issue 30

### DIFF
--- a/force-app/main/default/lwc/tableauViz/tableauViz.js
+++ b/force-app/main/default/lwc/tableauViz/tableauViz.js
@@ -138,9 +138,6 @@ export default class TableauViz extends LightningElement {
     // wait until the data is loaded. The tracked properties will trigger a refresh
     validateFiltersReady() {
         if (this.sfAdvancedFilter && !this.advancedFilterValue) {
-            console.log(
-                `Triggering record reload to get ${this.sfAdvancedFilter} value`
-            );
             this.trigger = this.sfAdvancedFilter;
             return false;
         }


### PR DESCRIPTION
There is a problem somewhere in SF that using an api value for the trigger on the wired service seems to sometimes have it be "undefined". I debugged this for quite a while with logging. I can see it is undefined when getRecord is called but clearly defined in renderedCallback. This "hack" is a way to force SF to rerun the wired service and assuming it finds the value, the update to the tracked property will trigger a rerender. Did a bunch of testing to see that this works.