### PR TITLE
Fixed viz initialization logic

### DIFF
--- a/force-app/main/default/lwc/tableauViz/tableauViz.js
+++ b/force-app/main/default/lwc/tableauViz/tableauViz.js
@@ -45,11 +45,10 @@ export default class TableauViz extends LightningElement {
         }
     }
 
-    connectedCallback() {
-        loadScript(this, tableauJSAPI).then(() => {
-            this.isLibLoaded = true;
-            this.renderViz();
-        });
+    async connectedCallback() {
+        await loadScript(this, tableauJSAPI);
+        this.isLibLoaded = true;
+        this.renderViz();
     }
 
     renderedCallback() {


### PR DESCRIPTION
Here's a clean proposal to fix #30.
It also addresses item 1 of #35: call to `loadScript` is only executed once.