### PR TITLE
change vizURL to vizUrl to make composition work

### DIFF
--- a/force-app/main/default/lwc/tableauViz/__tests__/tableauViz.test.js
+++ b/force-app/main/default/lwc/tableauViz/__tests__/tableauViz.test.js
@@ -51,7 +51,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.hideTabs = false;
         element.hideToolbar = true;
         element.height = 650;
@@ -71,7 +71,7 @@ describe('tableau-viz', () => {
             is: TableauViz
         });
         element.height = '550';
-        element.vizURL = VIZ_URL_NO_FILTERS;
+        element.vizUrl = VIZ_URL_NO_FILTERS;
 
         document.body.appendChild(element);
 
@@ -201,7 +201,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.tabAdvancedFilter = 'mockValue';
         document.body.appendChild(element);
 
@@ -221,7 +221,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.sfAdvancedFilter = 'mockValue';
         document.body.appendChild(element);
 
@@ -241,7 +241,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.sfAdvancedFilter = 'mockValue';
         element.tabAdvancedFilter = 'Name';
         document.body.appendChild(element);
@@ -264,7 +264,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.objectApiName = 'Account';
         element.recordId = 'mockId';
         element.sfAdvancedFilter = MISSING_FIELD;

--- a/force-app/main/default/lwc/tableauViz/__tests__/tableauViz.test.js
+++ b/force-app/main/default/lwc/tableauViz/__tests__/tableauViz.test.js
@@ -38,7 +38,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         document.body.appendChild(element);
 
         // Validation that the loadScript promise is called once.
@@ -92,7 +92,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.filterOnRecordId = false;
         element.height = '550';
         element.objectApiName = 'Account';
@@ -114,7 +114,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.filterOnRecordId = true;
         element.height = '550';
         element.objectApiName = 'Account';
@@ -138,7 +138,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = VIZ_URL;
+        element.vizUrl = VIZ_URL;
         element.filterOnRecordId = false;
         element.height = 650;
         element.objectApiName = 'Account';
@@ -166,7 +166,7 @@ describe('tableau-viz', () => {
         const element = createElement('c-tableau-viz', {
             is: TableauViz
         });
-        element.vizURL = 'invalid';
+        element.vizUrl = 'invalid';
         document.body.appendChild(element);
 
         await flushPromises();
@@ -184,7 +184,7 @@ describe('tableau-viz', () => {
             is: TableauViz
         });
         // eslint-disable-next-line no-script-url
-        element.vizURL = 'javascript:void(0)';
+        element.vizUrl = 'javascript:void(0)';
         document.body.appendChild(element);
 
         await flushPromises();

--- a/force-app/main/default/lwc/tableauViz/tableauViz.js
+++ b/force-app/main/default/lwc/tableauViz/tableauViz.js
@@ -10,7 +10,7 @@ import templateError from './tableauVizError.html';
 export default class TableauViz extends LightningElement {
     @api objectApiName;
     @api recordId;
-    @api vizURL;
+    @api vizUrl;
     @api hideTabs;
     @api hideToolbar;
     @api filterOnRecordId;
@@ -76,7 +76,7 @@ export default class TableauViz extends LightningElement {
         );
 
         // Configure viz URL
-        const vizToLoad = new URL(this.vizURL);
+        const vizToLoad = new URL(this.vizUrl);
         this.setVizDimensions(vizToLoad, containerDiv);
         this.setVizFilters(vizToLoad);
         const vizURLString = vizToLoad.toString();
@@ -103,11 +103,8 @@ export default class TableauViz extends LightningElement {
     validateInputs() {
         // Validate viz url
         try {
-            const vizUrl = new URL(this.vizURL);
-            if (
-                !(vizUrl.protocol === 'http:') &&
-                !(vizUrl.protocol === 'https:')
-            ) {
+            const u = new URL(this.vizUrl);
+            if (!(u.protocol === 'http:') && !(u.protocol === 'https:')) {
                 throw Error();
             }
         } catch (_) {

--- a/force-app/main/default/lwc/tableauViz/tableauViz.js-meta.xml
+++ b/force-app/main/default/lwc/tableauViz/tableauViz.js-meta.xml
@@ -13,7 +13,7 @@
     <targetConfigs>
     <targetConfig targets="lightning__RecordPage">
             <property
-                name="vizURL"
+                name="vizUrl"
                 type="String"
                 label="Enter the Viz URL"
                 required="true"
@@ -65,7 +65,7 @@
             targets="lightning__AppPage,lightning__HomePage,lightningCommunity__Default"
         >
             <property
-                name="vizURL"
+                name="vizUrl"
                 type="String"
                 label="Enter the Viz URL"
                 required="true"


### PR DESCRIPTION
This was needed to make composition like <c-tableau-viz viz-url={foo}></c-tableau-viz> work. SF converts viz-url into vizUrl. Unless I wanted to do something hacky like viz-uRL, this was needed and really the right fix.