### PR TITLE
Add *.tableau.com as a trusted site

### DIFF
--- a/force-app/main/default/cspTrustedSites/Tableau.cspTrustedSite-meta.xml
+++ b/force-app/main/default/cspTrustedSites/Tableau.cspTrustedSite-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CspTrustedSite xmlns="http://soap.sforce.com/2006/04/metadata">
+    <context>Communities</context>
+    <endpointUrl>https://public.tableau.com</endpointUrl>
+    <isActive>true</isActive>
+    <isApplicableToConnectSrc>false</isApplicableToConnectSrc>
+    <isApplicableToFontSrc>false</isApplicableToFontSrc>
+    <isApplicableToFrameSrc>true</isApplicableToFrameSrc>
+    <isApplicableToImgSrc>false</isApplicableToImgSrc>
+    <isApplicableToMediaSrc>false</isApplicableToMediaSrc>
+    <isApplicableToStyleSrc>false</isApplicableToStyleSrc>
+</CspTrustedSite>

--- a/force-app/main/default/cspTrustedSites/Tableau.cspTrustedSite-meta.xml
+++ b/force-app/main/default/cspTrustedSites/Tableau.cspTrustedSite-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CspTrustedSite xmlns="http://soap.sforce.com/2006/04/metadata">
     <context>Communities</context>
-    <endpointUrl>https://public.tableau.com</endpointUrl>
+    <endpointUrl>*.tableau.com</endpointUrl>
     <isActive>true</isActive>
     <isApplicableToConnectSrc>false</isApplicableToConnectSrc>
     <isApplicableToFontSrc>false</isApplicableToFontSrc>


### PR DESCRIPTION
In **Winter '21**, by default the viz component is blocked from Communities because of a CSP issue.

![CSP error](https://user-images.githubusercontent.com/5071767/93602531-01a8cc80-f9c3-11ea-98c9-4d80a689019c.png)

We need to add `public.tableau.com` as a CSP trusted site to fix that.
This can be done automatically by including this metadata file in the project/package.